### PR TITLE
fix content_audit_cron_schedules function to add cron jobs, not overwrite

### DIFF
--- a/inc/cron.php
+++ b/inc/cron.php
@@ -5,16 +5,17 @@ register_activation_hook( dirname ( __FILE__ )."/content-audit.php", 'content_au
 register_deactivation_hook( dirname ( __FILE__ )."/content-audit.php", 'content_audit_cron_deactivate' );
 
 // add custom time to cron
-function content_audit_cron_schedules( $param ) {
-	return array( 'weekly' => array( 
+function content_audit_cron_schedules( $schedules ) {
+	$schedules['weekly'] = array( 
 								'interval' => 60*60*24*7, 
 								'display'  => __( 'Once a Week', 'content-audit' )
-							 ) ,
-				  'monthly' => array( 
+						   );
+	$schedules['monthly'] = array( 
 								'interval' => 60*60*24*7*4, 
 								'display'  => __( 'Once a Month', 'content-audit' )
-							 ) 
-				 );
+							);
+
+	return $schedules;
 }
 add_filter( 'cron_schedules', 'content_audit_cron_schedules' );
 


### PR DESCRIPTION
This fixes #12 and likely resolves numerous other plugin, theme, core, and host conflicts from the plugin.

Having come to understand the issue and fix, this is a rather high priority issue to resolve.