### PR TITLE
set show_in_rest to true for the content_audit taxonomy

### DIFF
--- a/inc/taxonomy.php
+++ b/inc/taxonomy.php
@@ -25,6 +25,7 @@ function create_content_audit_tax() {
 			'show_tagcloud' => false,
 			'update_count_callback' => 'content_audit_term_count',
 			'helps' => __('Enter content attributes separated by commas.', 'content-audit'),
+			'show_in_rest' => true,
 		 )
 	 );
 }


### PR DESCRIPTION
[As of WordPress 5.0](https://make.wordpress.org/core/2018/12/06/the-rest-api-in-wordpress-5-0/):

> All custom taxonomies must have show_in_rest set to true in order to appear in the new editor.

This does just that and only that. It should also make [this person in the support forums](https://wordpress.org/support/topic/option-to-toggle-rest-api-support-for-content_audit-taxonomy/) very happy :)